### PR TITLE
fix a potential race condition

### DIFF
--- a/tezpool.py
+++ b/tezpool.py
@@ -52,8 +52,10 @@ def getCurrentCycle ():
 
 
 def getBlockHashByIndex (idx):
-	head_level = requests.get (conf['host'] + '/chains/main/blocks/head/header').json()['level']
-	return requests.get (conf['host'] + '/chains/main/blocks/head~' + str (head_level - idx) + '/header').json()['hash']
+	head = requests.get (conf['host'] + '/chains/main/blocks/head/header').json()
+	head_level = head['level']
+	head_hash = head['hash']
+	return requests.get (conf['host'] + '/chains/main/blocks/' + head_hash + '~' + str (head_level - idx) + '/header').json()['hash']
 
 def getFrozenBalance (cycle = None):
 	if cycle == None:


### PR DESCRIPTION
This fixes a potential race condition that can happen if there is a new block between the first and the second requests, which might put you at the wrong offset.

Here's the race condition:
```bash
tezos@tezos-mainnet:~$ curl localhost:8732/chains/main/blocks/head/header --silent | jq .level
106546
tezos@tezos-mainnet:~$ curl localhost:8732/chains/main/blocks/head~106446/header --silent | jq .level
100
tezos@tezos-mainnet:~$ curl localhost:8732/chains/main/blocks/head~106446/header --silent | jq .level
101
```

And this is the new proposed way for getting the block hash (index 100):
```bash
$ curl localhost:8732/chains/main/blocks/head/header --silent | jq
{
  "protocol": "PsYLVpVvgbLhAhoqAkMFUo6gudkJ9weNXhUYCiLDzcUpFpkk8Wt",
  "chain_id": "NetXdQprcVkpaWU",
  "hash": "BM5hJsnZtGuEPD5wyEc4sn8kBtG7CHHoPzBb1UdSDDeUjdPxurW",
  "level": 106555,
  "proto": 2,
  "predecessor": "BME5XAoimt9eQTRLngnJHkehi2Y16eMdDriG1NcJN9CmnV2T1Dz",
  "timestamp": "2018-09-16T22:21:46Z",
  "validation_pass": 4,
  "operations_hash": "LLoauqMTYYd8f3UrkyxWQqSGJwULqha5A9CjHJB2s52FfGh2Qj1SP",
  "fitness": [
    "00",
    "00000000002daefd"
  ],
  "context": "CoV3EdCYDtHVSTfJeEq3rBp2Sg3wxbFkNfn5u9HEQs93dJExtc1M",
  "priority": 0,
  "proof_of_work_nonce": "9816c0d362dd3369",
  "signature": "sigqBhccg9TR4VRGFJUcpWmhAh8w4ecJQ7goU5gpTHrw2x449QY4Lh9aJ8nPkstdxhWUjmcovpx2PtYwYP6q7vigwNm8Crdv"
}
tezos@tezos-mainnet:~$ curl localhost:8732/chains/main/blocks/BM5hJsnZtGuEPD5wyEc4sn8kBtG7CHHoPzBb1UdSDDeUjdPxurW~106455/header --silent | jq
{
  "protocol": "PtCJ7pwoxe8JasnHY8YonnLYjcVHmhiARPJvqcC6VfHT5s8k8sY",
  "chain_id": "NetXdQprcVkpaWU",
  "hash": "BML4nC9q85FmJdQpFUmTki9xy8dqZCTaPMNwqsbHkyU6DpMAhor",
  "level": 100,
  "proto": 1,
  "predecessor": "BL8rD6AoChiT2DcBWirsByGtcHuG6znq63ZqVQfdX3pPwRL8nSy",
  "timestamp": "2018-06-30T19:21:27Z",
  "validation_pass": 4,
  "operations_hash": "LLoahg5PaJCy7XpqrpQD6iweDaabaA8vZcUjoihQUDe4Sjiw3n3qZ",
  "fitness": [
    "00",
    "0000000000000c76"
  ],
  "context": "CoWXqn6U4LJrtSWwuoC75qM59wFDCYj9wpXHoayCqCB9NkMUgyN1",
  "priority": 0,
  "proof_of_work_nonce": "1cc495b863a15323",
  "signature": "sigjLbYSxuCp2mbNQnUQs26jEdW4gXLTTGcRUGErFXRVHVChezWYA7gTvxoaELXXjK56H1qpNvG9Vmn4jzAXfpMuwQmXywzE"
}
```